### PR TITLE
BREAKING feat: removes ::display in favor of ::print and ::eprint

### DIFF
--- a/examples/alignment.rs
+++ b/examples/alignment.rs
@@ -5,5 +5,5 @@ pub fn main() {
         .text_alignment(Alignment::Right)
         .box_alignment(Alignment::Right)
         .build()
-        .display("This billboard has been\nright aligned while we weren't looking!\n...why!??! ☹️");
+        .eprint("This billboard has been\nright aligned while we weren't looking!\n...why!??! ☹️");
 }

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -4,7 +4,7 @@ fn main() {
     Billboard::builder()
         .border_color(BorderColor::Blue)
         .build()
-        .display(&format!(
+        .eprint(&format!(
             "Hello, World!\nThis billboard has a {} border now!",
             console::style("blue").blue()
         ));

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -12,7 +12,7 @@ pub fn main() {
             top_right: "0".to_string(),
         }))
         .build()
-        .display(&format!(
+        .eprint(&format!(
             "This is a billboard\nwith a custom border\nwhich i think is {} {} cool",
             style("pretty").red(),
             style("pretty").green()

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,5 @@
 use billboard::Billboard;
 
 fn main() {
-    Billboard::default().display("Hello, World!");
+    Billboard::default().eprint("Hello, World!");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,28 @@ impl Billboard {
     /// ```
     /// use billboard::Billboard;
     ///
-    /// Billboard::default().display("Hello, World!\nNew lines can be created with the newline separator :).");
+    /// Billboard::default().print("Hello, World!\nNew lines can be created with the newline separator :).");
     /// ```
-    pub fn display(&self, content: impl Display) {
-        println!("{}", self.to_string(content.to_string().as_str()));
+    pub fn print(&self, content: impl Display) {
+        println!("{}", self.enclose(content));
+    }
+
+    /// Prints your `Billboard`ed content to `stderr`
+    /// If your content is long, separate it with line breaks (`\n`).
+    ///
+    /// If the user's terminal is too small, or something goes wrong with displaying
+    /// your content in a box, this function will print the content passed to it
+    /// with no modifications.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use billboard::Billboard;
+    ///
+    /// Billboard::default().eprint("Hello, World!\nNew lines can be created with the newline separator :).");
+    /// ```
+    pub fn eprint(&self, content: impl Display) {
+        println!("{}", self.enclose(content));
     }
 
     /// Get your content in a `Billboard` as a `String`.
@@ -92,10 +110,11 @@ impl Billboard {
     /// ```
     /// use billboard::Billboard;
     ///
-    /// let result = Billboard::default().to_string("Hello, World!");
+    /// let result = Billboard::default().enclose("Hello, World!");
     /// println!("{}", result);
     /// ```
-    pub fn to_string(&self, content: &str) -> String {
+    pub fn enclose(&self, content: impl Display) -> String {
+        let content = content.to_string();
         let border_color = match self.config.border_color {
             Some(color) => Style::from_dotted_str(&format!("{:?}", color).to_lowercase()),
             None => Style::default(),


### PR DESCRIPTION
this will break anybody relying on the `::display` function but I think it's better in the long run to make folks think about stderr or stdout up front.